### PR TITLE
Change CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-node.js.org
+node.captainwebservices.com


### PR DESCRIPTION
Hi! The CNAME file isn't currently resolving. It's blocking some stuff I'm trying to do for the official Node.js web presence. (See https://github.com/js-org/js.org/pull/3115.) Any chance I can convince you to either remove the CNAME file or repoint it at a subdomain that you currently control? I've put a suggestion in this pull request.